### PR TITLE
Better way of getting Model name and friendly name

### DIFF
--- a/lib/casting/cast_device.dart
+++ b/lib/casting/cast_device.dart
@@ -1,76 +1,133 @@
-import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'dart:convert' show utf8;
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'package:xml/xml.dart' as xml;
 import 'package:observable/observable.dart';
 
+/// Only Chromecast Type is supported
 enum CastDeviceType {
   Unknown,
   ChromeCast,
   AppleTV,
 }
 
-class CastDevice extends ChangeNotifier {
+enum CastModel {
+  GoogleHome,
+  GoogleMini,
+  GoogleMax,
+  GoogleHub,
+  ChromeCastAudio,
+  ChromeCast,
+  CastGroup,
+  NonGoogle,
+}
 
+class CastDevice extends ChangeNotifier {
   final String name;
   final String type;
   final String host;
   final int port;
+  final Map<String, Uint8List> attr;
 
-  String _friendlyName;
+  String friendlyName;
+  String modelName;
 
-  CastDevice({
-    this.name,
-    this.type,
-    this.host,
-    this.port,
-  }) {
+  /// Model of device
+  /// Used for sorting
+  CastModel castModel;
 
-    // fetch device info if possible
-    if (CastDeviceType.ChromeCast == deviceType) {
-      // for now we only request name, because we only use it to get the 'friendly name'
-      // Possible parameters: version,audio,name,build_info,detail,device_info,net,wifi,setup,settings,opt_in,opencast,multizone,proxy,night_mode_params,user_eq,room_equalizer
-      // see: https://rithvikvibhu.github.io/GHLocalApi/#device-info
-      http.get('http://${host}:8008/setup/eureka_info?params=name')
-          .then((response) {
-        print("EUREKA: Response status: ${response.statusCode}");
-        print("EUREKA: Response body: ${response.body}");
-        Map deviceInfo = jsonDecode(response.body);
-        _friendlyName = deviceInfo['name'];
-        notifyChange();
-      });
-      // old way: xml from device-desc.xml
-//      http.get('http://${host}:8008/ssdp/device-desc.xml')
-//          .then((response) {
-//        print("Response status: ${response.statusCode}");
-//        print("Response body: ${response.body}");
-//        xml.XmlDocument document = xml.parse(response.body);
-//        xml.XmlElement deviceElement =
-//            document.findElements('root').first
-//            .findElements('device').first;
-//        _friendlyName = deviceElement.findElements('friendlyName').first.text;
-//        notifyChange();
-//      });
+  CastDevice({this.name, this.type, this.host, this.port, this.attr}) {
+    modelName = utf8.decode(attr['md']);
+    friendlyName = utf8.decode(attr['fn']);
+
+    switch (modelName) {
+      case "Google Home":
+        castModel = CastModel.GoogleHome;
+        break;
+      case "Google Home Hub":
+        castModel = CastModel.GoogleHub;
+        break;
+      case "Google Home Mini":
+        castModel = CastModel.GoogleMini;
+        break;
+      case "Google Home Max":
+        castModel = CastModel.GoogleMax;
+        break;
+      case "Chromecast":
+        castModel = CastModel.ChromeCast;
+        break;
+      case "Chromecast Audio":
+        castModel = CastModel.ChromeCastAudio;
+        break;
+      case "Google Cast Group":
+        castModel = CastModel.CastGroup;
+        break;
+      default:
+        castModel = CastModel.NonGoogle;
+        break;
     }
-    else if (CastDeviceType.AppleTV == deviceType) {
-      // todo
-    }
-
   }
+
 
   CastDeviceType get deviceType {
     if (type.startsWith('_googlecast._tcp')) {
       return CastDeviceType.ChromeCast;
-    }
-    else if (type.startsWith('_airplay._tcp')) {
+    } else if (type.startsWith('_airplay._tcp')) {
       return CastDeviceType.AppleTV;
     }
     return CastDeviceType.Unknown;
   }
 
-  String get friendlyName {
-    if (null != _friendlyName) {
-      return _friendlyName;
-    }
-    return name;
-  }
 
+
+  /// Comparator
+  /// In a List, the order will be:
+  /// Home,mini,max,hub < Chromecast and Audio < Cast Group and non google
+  int compareTo(CastDevice b) {
+    switch (this.castModel) {
+      case CastModel.GoogleHome:
+      case CastModel.GoogleMax:
+      case CastModel.GoogleMini:
+      case CastModel.GoogleHub:
+        // If b is not a Google home, return -1 because a is smaller (in list order) than b
+        if (b.castModel == CastModel.ChromeCastAudio ||
+            b.castModel == CastModel.ChromeCast ||
+            b.castModel == CastModel.CastGroup ||
+            b.castModel == CastModel.NonGoogle) {
+          return -1;
+        } else {
+          return this.host.compareTo(b.host);
+        }
+        break;
+      case CastModel.ChromeCast:
+      case CastModel.ChromeCastAudio:
+        // if a is chromecast and b is home, a must go UNDER HOME
+        if (b.castModel == CastModel.GoogleHome ||
+            b.castModel == CastModel.GoogleMini ||
+            b.castModel == CastModel.GoogleMax ||
+            b.castModel == CastModel.GoogleHub) {
+          return 1; // Go down under GoogleHome
+        } else if (b.castModel == CastModel.CastGroup || b.castModel == CastModel.NonGoogle) {
+          return -1; // Before castGroup and NonGoogle in list
+        } else {
+          return this.host.compareTo(b.host);
+        }
+        break;
+      case CastModel.NonGoogle:
+      case CastModel.CastGroup:
+        if (b.castModel != CastModel.CastGroup && b.castModel != CastModel.NonGoogle) {
+          return 1;
+        } else {
+          return this.host.compareTo(b.host);
+        }
+        break;
+      default:
+        // Otherwise, do a comparison of IPs
+        return this.host.compareTo(b.host);
+        break;
+    }
+
+  }
 }


### PR DESCRIPTION
Made this branch only for pull request back to upstream _(only wanted to put **cast_device.dart** in the pull request)_ about Getting friendly name and model name. 

It also adds a comparator for sorting models. 