### PR TITLE
Update CastDevice to better recognize deviceType values

### DIFF
--- a/lib/casting/cast_device.dart
+++ b/lib/casting/cast_device.dart
@@ -89,10 +89,10 @@ class CastDevice extends ChangeNotifier {
   }
 
   CastDeviceType get deviceType {
-    if (type.startsWith('_googlecast._tcp')) {
+    if (type.contains('_googlecast._tcp')) {
       return CastDeviceType.ChromeCast;
     }
-    else if (type.startsWith('_airplay._tcp')) {
+    else if (type.contains('_airplay._tcp')) {
       return CastDeviceType.AppleTV;
     }
     return CastDeviceType.Unknown;


### PR DESCRIPTION
Update CastDevice to better recognize deviceType values by replacing `startsWith` with `contains` test against device type string.

I observed type values of `._googlecast._tcp` (with leading dot).  I confess that I don't know what the true source of this value is/if there is a better fix - figured this is harmless/slight improvement.