### PR TITLE
Close stream when disconnected

### DIFF
--- a/lib/casting/cast_sender.dart
+++ b/lib/casting/cast_sender.dart
@@ -374,6 +374,8 @@ class CastSender extends Object {
   }
 
   void _dispose() {
+     castSessionController.close();
+     castMediaStatusController.close();
     _socket = null;
     _heartbeatChannel = null;
     _connectionChannel = null;


### PR DESCRIPTION
By closing the streams, we can be notified when the chromecast gets disconnected by an external factor by observing the `onDone` callback.

Example:

```dart
StreamSubscription subscription = _castSender.castSessionController.stream.listen(
  (CastSession castSession) {
    print('CastSession update ${castSession.isConnected.toString()}');
  },
  onDone: () {
    print('CastSession has finished!');
  },
);
```