### PR TITLE
Fix `reusePort not supported` (Android)

### DIFF
--- a/lib/utils/mdns_find_chromecast.dart
+++ b/lib/utils/mdns_find_chromecast.dart
@@ -24,7 +24,7 @@ Future<List<CastDevice>> find_chromecasts() async {
   // Start the client with default options.
   await client.start();
 
-  // Get the PTR recod for the service.
+  // Get the PTR record for the service.
   await for (PtrResourceRecord ptr in client
       .lookup<PtrResourceRecord>(ResourceRecordQuery.serverPointer(name))) {
     // Use the domainName from the PTR record to get the SRV record,

--- a/lib/utils/mdns_find_chromecast.dart
+++ b/lib/utils/mdns_find_chromecast.dart
@@ -14,7 +14,7 @@ class CastDevice {
 
 Future<List<CastDevice>> find_chromecasts() async {
   const String name = '_googlecast._tcp.local';
-  final client = MDnsClient(
+  final MDnsClient client = MDnsClient(
       rawDatagramSocketFactory: (dynamic host, int port,
               {bool reuseAddress, bool reusePort, int ttl}) =>
           RawDatagramSocket.bind(host, port,

--- a/lib/utils/mdns_find_chromecast.dart
+++ b/lib/utils/mdns_find_chromecast.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:multicast_dns/multicast_dns.dart';
 
 class CastDevice {
@@ -12,7 +14,11 @@ class CastDevice {
 
 Future<List<CastDevice>> find_chromecasts() async {
   const String name = '_googlecast._tcp.local';
-  final MDnsClient client = MDnsClient();
+  final client = MDnsClient(
+      rawDatagramSocketFactory: (dynamic host, int port,
+              {bool reuseAddress, bool reusePort, int ttl}) =>
+          RawDatagramSocket.bind(host, port,
+              reuseAddress: true, reusePort: false, ttl: ttl));
 
   final Map<String, CastDevice> map = {};
   // Start the client with default options.


### PR DESCRIPTION
This seems to correct the symptom described in #25 on Android; `find_chromecasts` now finds devices on the network.

With this fix I still couldn't completely clear #25 on Windows. Although I didn't get `reusePort not supported` anymore, the follow-on exception `SocketException: Failed to create datagram socket (OS Error: The requested address is not valid in its context.
, errno = 10049), address = , port = 5353`  is still present, so it's still true that the example doesn't work unless you bypass the MDNS capability by specifying `--host`

Still, this may be an improvement on its own you'd want.