### PR TITLE
Null safety

### DIFF
--- a/example/index.dart
+++ b/example/index.dart
@@ -50,19 +50,17 @@ void main(List<String> arguments) async {
     for (int i = 0; i < devices.length; i++) {
       int index = i + 1;
       find_chromecast.CastDevice device = devices[i];
-      print("${index}: ${device.name}");
+      print("$index: ${device.name}");
     }
 
     print("Pick a device (1-${devices.length}):");
 
-    int? choice = null;
+    int? choice;
 
     while (choice == null || choice < 0 || choice > devices.length) {
       choice = int.parse(stdin.readLineSync()!);
-      if (choice == null) {
-        print(
-            "Please pick a number (1-${devices.length}) or press return to search again");
-      }
+      print(
+          "Please pick a number (1-${devices.length}) or press return to search again");
     }
 
     find_chromecast.CastDevice pickedDevice = devices[choice - 1];
@@ -70,9 +68,9 @@ void main(List<String> arguments) async {
     host = pickedDevice.ip!;
     port = pickedDevice.port;
 
-    print("Connecting to device: ${host}:${port}");
+    print("Connecting to device: $host:$port");
 
-    log.fine("Picked: ${pickedDevice}");
+    log.fine("Picked: $pickedDevice");
   }
 
   startCasting(media, host, port, argResults['append']);
@@ -85,10 +83,8 @@ void startCasting(
   // try to load previous state saved as json in saved_cast_state.json
   Map? savedState;
   try {
-    File savedStateFile = await File("./saved_cast_state.json");
-    if (null != savedStateFile) {
-      savedState = jsonDecode(await savedStateFile.readAsString());
-    }
+    File savedStateFile = File("./saved_cast_state.json");
+    savedState = jsonDecode(await savedStateFile.readAsString());
   } catch (e) {
     // does not exist yet
     log.warning('error fetching saved state' + e.toString());
@@ -115,7 +111,7 @@ void startCasting(
   castSender.castSessionController.stream
       .listen((CastSession? castSession) async {
     if (castSession!.isConnected) {
-      File savedStateFile = await File('./saved_cast_state.json');
+      File savedStateFile = File('./saved_cast_state.json');
       Map map = {
         'time': DateTime.now().millisecondsSinceEpoch,
       }..addAll(castSession.toMap());
@@ -193,7 +189,7 @@ void startCasting(
 }
 
 void _handleUserInput(CastSender castSender, List<int> data) {
-  if (null == castSender || data.length == 0) return;
+  if (data.length == 0) return;
 
   int keyCode = data.last;
 

--- a/example/index.dart
+++ b/example/index.dart
@@ -34,7 +34,7 @@ void main(List<String> arguments) async {
       argResults.rest.map((String i) => CastMedia(contentId: i)).toList();
 
   String host = argResults['host'];
-  int port = int.parse(argResults['port']);
+  int? port = int.parse(argResults['port']);
   if ('' == host.trim()) {
     // search!
     print('Looking for ChromeCast devices...');
@@ -55,10 +55,10 @@ void main(List<String> arguments) async {
 
     print("Pick a device (1-${devices.length}):");
 
-    int choice = null;
+    int? choice = null;
 
     while (choice == null || choice < 0 || choice > devices.length) {
-      choice = int.parse(stdin.readLineSync());
+      choice = int.parse(stdin.readLineSync()!);
       if (choice == null) {
         print(
             "Please pick a number (1-${devices.length}) or press return to search again");
@@ -67,7 +67,7 @@ void main(List<String> arguments) async {
 
     find_chromecast.CastDevice pickedDevice = devices[choice - 1];
 
-    host = pickedDevice.ip;
+    host = pickedDevice.ip!;
     port = pickedDevice.port;
 
     print("Connecting to device: ${host}:${port}");
@@ -79,11 +79,11 @@ void main(List<String> arguments) async {
 }
 
 void startCasting(
-    List<CastMedia> media, String host, int port, bool append) async {
+    List<CastMedia> media, String host, int? port, bool? append) async {
   log.fine('Start Casting');
 
   // try to load previous state saved as json in saved_cast_state.json
-  Map savedState;
+  Map? savedState;
   try {
     File savedStateFile = await File("./saved_cast_state.json");
     if (null != savedStateFile) {
@@ -113,8 +113,8 @@ void startCasting(
   // listen for cast session updates and save the state when
   // the device is connected
   castSender.castSessionController.stream
-      .listen((CastSession castSession) async {
-    if (castSession.isConnected) {
+      .listen((CastSession? castSession) async {
+    if (castSession!.isConnected) {
       File savedStateFile = await File('./saved_cast_state.json');
       Map map = {
         'time': DateTime.now().millisecondsSinceEpoch,
@@ -124,13 +124,13 @@ void startCasting(
     }
   });
 
-  CastMediaStatus prevMediaStatus;
+  CastMediaStatus? prevMediaStatus;
   // Listen for media status updates, such as pausing, playing, seeking, playback etc.
   castSender.castMediaStatusController.stream
-      .listen((CastMediaStatus mediaStatus) {
+      .listen((CastMediaStatus? mediaStatus) {
     // show progress for example
     if (null != prevMediaStatus &&
-        mediaStatus.volume != prevMediaStatus.volume) {
+        mediaStatus!.volume != prevMediaStatus!.volume) {
       // volume just updated
       log.info('Volume just updated to ${mediaStatus.volume}');
     }
@@ -210,9 +210,9 @@ void _handleUserInput(CastSender castSender, List<int> data) {
     // left or right = seek 10s back or forth
     double seekBy = 67 == keyCode ? 10.0 : -10.0;
     if (null != castSender.castSession &&
-        null != castSender.castSession.castMediaStatus) {
+        null != castSender.castSession!.castMediaStatus) {
       castSender.seek(
-        max(0.0, castSender.castSession.castMediaStatus.position + seekBy),
+        max(0.0, castSender.castSession!.castMediaStatus!.position! + seekBy),
       );
     }
   }

--- a/lib/casting/cast_channel.dart
+++ b/lib/casting/cast_channel.dart
@@ -35,8 +35,8 @@ abstract class CastChannel {
     castMessage.payloadUtf8 = jsonEncode(payload);
 
     Uint8List bytes = castMessage.writeToBuffer();
-    Uint32List headers =
-        Uint32List.fromList(writeUInt32BE(List<int?>(4), bytes.lengthInBytes));
+    Uint32List headers = Uint32List.fromList(writeUInt32BE(
+        List<int?>.filled(4, null, growable: false), bytes.lengthInBytes));
     Uint32List fullData =
         Uint32List.fromList(headers.toList()..addAll(bytes.toList()));
 

--- a/lib/casting/cast_channel.dart
+++ b/lib/casting/cast_channel.dart
@@ -8,16 +8,16 @@ import '../proto/cast_channel.pb.dart';
 abstract class CastChannel {
   static int _requestId = 1;
 
-  final Socket _socket;
-  String _sourceId;
-  String _destinationId;
-  String _namespace;
+  final Socket? _socket;
+  String? _sourceId;
+  String? _destinationId;
+  String? _namespace;
 
   CastChannel(
       this._socket, this._sourceId, this._destinationId, this._namespace);
 
-  CastChannel.CreateWithSocket(Socket socket,
-      {String sourceId, String destinationId, String namespace})
+  CastChannel.CreateWithSocket(Socket? socket,
+      {String? sourceId, String? destinationId, String? namespace})
       : _socket = socket,
         _sourceId = sourceId,
         _destinationId = destinationId,
@@ -28,15 +28,15 @@ abstract class CastChannel {
 
     CastMessage castMessage = CastMessage();
     castMessage.protocolVersion = CastMessage_ProtocolVersion.CASTV2_1_0;
-    castMessage.sourceId = _sourceId;
-    castMessage.destinationId = _destinationId;
-    castMessage.namespace = _namespace;
+    castMessage.sourceId = _sourceId!;
+    castMessage.destinationId = _destinationId!;
+    castMessage.namespace = _namespace!;
     castMessage.payloadType = CastMessage_PayloadType.STRING;
     castMessage.payloadUtf8 = jsonEncode(payload);
 
     Uint8List bytes = castMessage.writeToBuffer();
     Uint32List headers =
-        Uint32List.fromList(writeUInt32BE(List<int>(4), bytes.lengthInBytes));
+        Uint32List.fromList(writeUInt32BE(List<int?>(4), bytes.lengthInBytes));
     Uint32List fullData =
         Uint32List.fromList(headers.toList()..addAll(bytes.toList()));
 
@@ -48,7 +48,7 @@ abstract class CastChannel {
       print('PING');
     }
 
-    _socket.add(fullData);
+    _socket!.add(fullData);
 
     _requestId++;
   }

--- a/lib/casting/cast_device.dart
+++ b/lib/casting/cast_device.dart
@@ -6,7 +6,8 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:logging/logging.dart';
-import 'package:observable/observable.dart';
+
+import 'package:flutter/widgets.dart';
 
 enum CastDeviceType {
   Unknown,
@@ -28,10 +29,10 @@ enum GoogleCastModelType {
 class CastDevice extends ChangeNotifier {
   final Logger log = Logger('CastDevice');
 
-  final String name;
-  final String type;
-  final String host;
-  final int port;
+  final String? name;
+  final String? type;
+  final String? host;
+  final int? port;
 
   /// Contains the information about the device.
   /// You can decode with utf8 a bunch of information
@@ -45,10 +46,10 @@ class CastDevice extends ChangeNotifier {
   /// * ca - Unknown (e.g. "1234");
   /// * ic - Icon path (e.g. "/setup/icon.png");
   /// * ve - Version (e.g. "04").
-  final Map<String, Uint8List> attr;
+  final Map<String, Uint8List>? attr;
 
-  String _friendlyName;
-  String _modelName;
+  String? _friendlyName;
+  String? _modelName;
 
   CastDevice({
     this.name,
@@ -62,10 +63,10 @@ class CastDevice extends ChangeNotifier {
 
   void initDeviceInfo() async {
     if (CastDeviceType.ChromeCast == deviceType) {
-      if (null != attr && null != attr['fn']) {
-        _friendlyName = utf8.decode(attr['fn']);
-        if (null != attr['md']) {
-          _modelName = utf8.decode(attr['md']);
+      if (null != attr && null != attr!['fn']) {
+        _friendlyName = utf8.decode(attr!['fn']!);
+        if (null != attr!['md']) {
+          _modelName = utf8.decode(attr!['md']!);
         }
       } else {
         // Attributes are not guaranteed to be set, if not set fetch them via the eureka_info url
@@ -77,8 +78,9 @@ class CastDevice extends ChangeNotifier {
                 ((X509Certificate cert, String host, int port) =>
                     trustSelfSigned);
           IOClient ioClient = new IOClient(httpClient);
-          http.Response response = await ioClient.get(
+          final uri = Uri.parse(
               'https://${host}:8443/setup/eureka_info?params=name,device_info');
+          http.Response response = await ioClient.get(uri);
           Map deviceInfo = jsonDecode(response.body);
 
           if (deviceInfo['name'] != null && deviceInfo['name'] != 'Unknown') {
@@ -95,26 +97,26 @@ class CastDevice extends ChangeNotifier {
         }
       }
     }
-    notifyChange();
+    notifyListeners();
   }
 
   CastDeviceType get deviceType {
-    if (type.contains('_googlecast._tcp')) {
+    if (type!.contains('_googlecast._tcp')) {
       return CastDeviceType.ChromeCast;
-    } else if (type.contains('_airplay._tcp')) {
+    } else if (type!.contains('_airplay._tcp')) {
       return CastDeviceType.AppleTV;
     }
     return CastDeviceType.Unknown;
   }
 
-  String get friendlyName {
+  String? get friendlyName {
     if (null != _friendlyName) {
       return _friendlyName;
     }
     return name;
   }
 
-  String get modelName => _modelName;
+  String? get modelName => _modelName;
 
   GoogleCastModelType get googleModelType {
     switch (modelName) {

--- a/lib/casting/cast_device.dart
+++ b/lib/casting/cast_device.dart
@@ -79,7 +79,7 @@ class CastDevice extends ChangeNotifier {
                     trustSelfSigned);
           IOClient ioClient = new IOClient(httpClient);
           final uri = Uri.parse(
-              'https://${host}:8443/setup/eureka_info?params=name,device_info');
+              'https://$host:8443/setup/eureka_info?params=name,device_info');
           http.Response response = await ioClient.get(uri);
           Map deviceInfo = jsonDecode(response.body);
 
@@ -124,7 +124,6 @@ class CastDevice extends ChangeNotifier {
         return GoogleCastModelType.GoogleHome;
       case "Google Home Hub":
         return GoogleCastModelType.GoogleHub;
-        break;
       case "Google Home Mini":
         return GoogleCastModelType.GoogleMini;
       case "Google Home Max":

--- a/lib/casting/cast_media.dart
+++ b/lib/casting/cast_media.dart
@@ -1,11 +1,11 @@
 class CastMedia {
 
-  final String contentId;
-  String title;
+  final String? contentId;
+  String? title;
   bool autoPlay = true;
   double position;
   String contentType;
-  List<String> images;
+  List<String>? images;
 
   CastMedia({
     this.contentId,

--- a/lib/casting/cast_media_status.dart
+++ b/lib/casting/cast_media_status.dart
@@ -7,7 +7,7 @@ class CastMediaStatus {
 
   dynamic _sessionId;
 
-  final String _nativeStatus;
+  final String? _nativeStatus;
   final bool _isPlaying;
   final bool _isPaused;
   final bool _isMuted ;
@@ -17,9 +17,9 @@ class CastMediaStatus {
   final bool _hasError;
   final bool _isLoading;
   final bool _isBuffering;
-  final double _volume;
-  final double _position;
-  final Map _media;
+  final double? _volume;
+  final double? _position;
+  final Map? _media;
 
   CastMediaStatus.fromChromeCastMediaStatus(Map mediaStatus)
       : _sessionId = mediaStatus['mediaSessionId'],
@@ -39,7 +39,7 @@ class CastMediaStatus {
 
   dynamic get sessionId => _sessionId;
 
-  String get nativeStatus => _nativeStatus;
+  String? get nativeStatus => _nativeStatus;
 
   bool get isIdle => _isIdle;
 
@@ -59,11 +59,11 @@ class CastMediaStatus {
 
   bool get hasError => _hasError;
 
-  double get volume => _volume;
+  double? get volume => _volume;
 
-  double get position => _position;
+  double? get position => _position;
 
-  Map get media => _media;
+  Map? get media => _media;
 
   @override
   String toString() {

--- a/lib/casting/cast_sender.dart
+++ b/lib/casting/cast_sender.dart
@@ -22,23 +22,23 @@ class CastSender extends Object {
   final Logger log = new Logger('CastSender');
   final CastDevice device;
 
-  SecureSocket _socket;
+  SecureSocket? _socket;
 
-  ConnectionChannel _connectionChannel;
-  HeartbeatChannel _heartbeatChannel;
-  ReceiverChannel _receiverChannel;
-  MediaChannel _mediaChannel;
+  ConnectionChannel? _connectionChannel;
+  HeartbeatChannel? _heartbeatChannel;
+  ReceiverChannel? _receiverChannel;
+  MediaChannel? _mediaChannel;
 
-  bool connectionDidClose;
+  late bool connectionDidClose;
 
 //  Timer _heartbeatTimer;
-  Timer _mediaCurrentTimeTimer;
+  Timer? _mediaCurrentTimeTimer;
 
-  CastSession _castSession;
-  StreamController<CastSession> castSessionController;
-  StreamController<CastMediaStatus> castMediaStatusController;
-  List<CastMedia> _contentQueue;
-  CastMedia _currentCastMedia;
+  CastSession? _castSession;
+  late StreamController<CastSession?> castSessionController;
+  late StreamController<CastMediaStatus?> castMediaStatusController;
+  late List<CastMedia> _contentQueue;
+  CastMedia? _currentCastMedia;
 
   CastSender(this.device) {
     // TODO: _airplay._tcp
@@ -63,7 +63,7 @@ class CastSender extends Object {
       return false;
     }
 
-    _connectionChannel.sendMessage({'type': 'CONNECT'});
+    _connectionChannel!.sendMessage({'type': 'CONNECT'});
 
     // start heartbeat
     _heartbeatTick();
@@ -75,7 +75,7 @@ class CastSender extends Object {
     return true;
   }
 
-  Future<bool> reconnect({String sourceId, String destinationId}) async {
+  Future<bool> reconnect({String? sourceId, String? destinationId}) async {
     _castSession =
         CastSession(sourceId: sourceId, destinationId: destinationId);
     bool connected = await connect();
@@ -85,7 +85,7 @@ class CastSender extends Object {
 
     _mediaChannel = MediaChannel.Create(
         socket: _socket, sourceId: sourceId, destinationId: destinationId);
-    _mediaChannel.sendMessage({'type': 'GET_STATUS'});
+    _mediaChannel!.sendMessage({'type': 'GET_STATUS'});
 
     // now wait for the media to actually get a status?
     bool didReconnect = await _waitForMediaStatus();
@@ -101,7 +101,7 @@ class CastSender extends Object {
       }
 
       try {
-        castMediaStatusController.add(_castSession.castMediaStatus);
+        castMediaStatusController.add(_castSession!.castMediaStatus);
       } catch (e) {
         log.severe(
             "Could not add the CastMediaStatus to the CastSession Stream Controller: events will not be triggered");
@@ -114,22 +114,22 @@ class CastSender extends Object {
 
   Future<bool> disconnect() async {
     if (null != _connectionChannel && null != _castSession?.castMediaStatus) {
-      _connectionChannel.sendMessage({
+      _connectionChannel!.sendMessage({
         'type': 'CLOSE',
-        'sessionId': _castSession.castMediaStatus.sessionId,
+        'sessionId': _castSession!.castMediaStatus!.sessionId,
       });
     }
     if (null != _socket) {
-      await _socket.destroy();
+      await _socket!.destroy();
     }
     _dispose();
     connectionDidClose = true;
     return true;
   }
 
-  void launch([String appId]) {
+  void launch([String? appId]) {
     if (null != _receiverChannel) {
-      _receiverChannel.sendMessage({
+      _receiverChannel!.sendMessage({
         'type': 'LAUNCH',
         'appId': appId ?? 'CC1AD845',
       });
@@ -155,9 +155,9 @@ class CastSender extends Object {
   void _castMediaAction(type, [params]) {
     if (null == params) params = {};
     if (null != _mediaChannel && null != _castSession?.castMediaStatus) {
-      _mediaChannel.sendMessage(params
+      _mediaChannel!.sendMessage(params
         ..addAll({
-          'mediaSessionId': _castSession.castMediaStatus.sessionId,
+          'mediaSessionId': _castSession!.castMediaStatus!.sessionId,
           'type': type,
         }));
     }
@@ -197,30 +197,30 @@ class CastSender extends Object {
     _castMediaAction('VOLUME', map);
   }
 
-  CastSession get castSession => _castSession;
+  CastSession? get castSession => _castSession;
 
   // private
 
-  Future<SecureSocket> _createSocket() async {
+  Future<SecureSocket?> _createSocket() async {
     if (null == _socket) {
       try {
         log.fine('Connecting to ${device.host}:${device.port}');
 
-        _socket = await SecureSocket.connect(device.host, device.port,
+        _socket = await SecureSocket.connect(device.host, device.port!,
             onBadCertificate: (X509Certificate certificate) => true,
             timeout: Duration(seconds: 10));
 
         _connectionChannel = ConnectionChannel.create(_socket,
-            sourceId: _castSession.sourceId,
-            destinationId: _castSession.destinationId);
+            sourceId: _castSession!.sourceId,
+            destinationId: _castSession!.destinationId);
         _heartbeatChannel = HeartbeatChannel.create(_socket,
-            sourceId: _castSession.sourceId,
-            destinationId: _castSession.destinationId);
+            sourceId: _castSession!.sourceId,
+            destinationId: _castSession!.destinationId);
         _receiverChannel = ReceiverChannel.create(_socket,
-            sourceId: _castSession.sourceId,
-            destinationId: _castSession.destinationId);
+            sourceId: _castSession!.sourceId,
+            destinationId: _castSession!.destinationId);
 
-        _socket.listen(_onSocketData, onDone: _dispose);
+        _socket!.listen(_onSocketData, onDone: _dispose);
       } catch (e) {
         log.fine(e.toString());
         return null;
@@ -260,14 +260,14 @@ class CastSender extends Object {
         _castSession = _castSession
           ..mergeWithChromeCastSessionMap(payload['status']['applications'][0]);
         _connectionChannel = ConnectionChannel.create(_socket,
-            sourceId: _castSession.sourceId,
-            destinationId: _castSession.destinationId);
-        _connectionChannel.sendMessage({'type': 'CONNECT'});
+            sourceId: _castSession!.sourceId,
+            destinationId: _castSession!.destinationId);
+        _connectionChannel!.sendMessage({'type': 'CONNECT'});
         _mediaChannel = MediaChannel.Create(
             socket: _socket,
-            sourceId: _castSession.sourceId,
-            destinationId: _castSession.destinationId);
-        _mediaChannel.sendMessage({'type': 'GET_STATUS'});
+            sourceId: _castSession!.sourceId,
+            destinationId: _castSession!.destinationId);
+        _mediaChannel!.sendMessage({'type': 'GET_STATUS'});
 
         try {
           castSessionController.add(_castSession);
@@ -281,43 +281,43 @@ class CastSender extends Object {
   }
 
   Future<bool> _waitForMediaStatus() async {
-    while (false == _castSession.isConnected) {
+    while (false == _castSession!.isConnected) {
       await Future.delayed(Duration(milliseconds: 100));
       if (connectionDidClose) return false;
     }
-    return _castSession.isConnected;
+    return _castSession!.isConnected;
   }
 
   void _handleMediaStatus(Map payload) {
     log.fine('Handle media status: ' + payload.toString());
 
     if (null != payload['status']) {
-      if (!_castSession.isConnected) {
-        _castSession.isConnected = true;
+      if (!_castSession!.isConnected) {
+        _castSession!.isConnected = true;
         _handleContentQueue();
       }
 
       if (payload['status'].length > 0) {
-        _castSession.castMediaStatus =
+        _castSession!.castMediaStatus =
             CastMediaStatus.fromChromeCastMediaStatus(payload['status'][0]);
 
-        log.fine('Media status ${_castSession.castMediaStatus.toString()}');
+        log.fine('Media status ${_castSession!.castMediaStatus.toString()}');
 
-        if (_castSession.castMediaStatus.isFinished) {
+        if (_castSession!.castMediaStatus!.isFinished) {
           _handleContentQueue();
         }
 
-        if (_castSession.castMediaStatus.isPlaying) {
+        if (_castSession!.castMediaStatus!.isPlaying) {
           _mediaCurrentTimeTimer =
               Timer(Duration(seconds: 1), _getMediaCurrentTime);
-        } else if (_castSession.castMediaStatus.isPaused &&
+        } else if (_castSession!.castMediaStatus!.isPaused &&
             null != _mediaCurrentTimeTimer) {
-          _mediaCurrentTimeTimer.cancel();
+          _mediaCurrentTimeTimer!.cancel();
           _mediaCurrentTimeTimer = null;
         }
 
         try {
-          castMediaStatusController.add(_castSession.castMediaStatus);
+          castMediaStatusController.add(_castSession!.castMediaStatus);
         } catch (e) {
           log.severe(
               "Could not add the CastMediaStatus to the CastSession Stream Controller: events will not be triggered");
@@ -340,8 +340,8 @@ class CastSender extends Object {
     if (null == _mediaChannel || _contentQueue.isEmpty) {
       return;
     }
-    if (null != _castSession.castMediaStatus &&
-        !_castSession.castMediaStatus.isFinished &&
+    if (null != _castSession!.castMediaStatus &&
+        !_castSession!.castMediaStatus!.isFinished &&
         !forceNext) {
       // don't handle the next in the content queue, because we only want
       // to play the 'next' content if it's not already playing.
@@ -350,14 +350,14 @@ class CastSender extends Object {
     _currentCastMedia = _contentQueue.elementAt(0);
     if (null != _currentCastMedia) {
       _contentQueue = _contentQueue.getRange(1, _contentQueue.length).toList();
-      _mediaChannel.sendMessage(_currentCastMedia.toChromeCastMap());
+      _mediaChannel!.sendMessage(_currentCastMedia!.toChromeCastMap());
     }
   }
 
   void _getMediaCurrentTime() {
     if (null != _mediaChannel &&
         true == _castSession?.castMediaStatus?.isPlaying) {
-      _mediaChannel.sendMessage({
+      _mediaChannel!.sendMessage({
         'type': 'GET_STATUS',
       });
     }
@@ -365,7 +365,7 @@ class CastSender extends Object {
 
   void _heartbeatTick() {
     if (null != _heartbeatChannel) {
-      _heartbeatChannel.sendMessage({'type': 'PING'});
+      _heartbeatChannel!.sendMessage({'type': 'PING'});
 
 //      _heartbeatTimer = Timer(Duration(seconds: 5), _heartbeatTick);
       Timer(Duration(seconds: 5), _heartbeatTick);
@@ -385,7 +385,7 @@ class CastSender extends Object {
   }
 
   @override
-  logError(String message, [Error error]) {
+  logError(String message, [Error? error]) {
     // TODO: implement logError
     return null;
   }

--- a/lib/casting/cast_sender.dart
+++ b/lib/casting/cast_sender.dart
@@ -119,9 +119,8 @@ class CastSender extends Object {
         'sessionId': _castSession!.castMediaStatus!.sessionId,
       });
     }
-    if (null != _socket) {
-      await _socket!.destroy();
-    }
+
+    _socket?.destroy();
     _dispose();
     connectionDidClose = true;
     return true;
@@ -235,18 +234,16 @@ class CastSender extends Object {
     CastMessage message = CastMessage.fromBuffer(slice);
     if (null != message) {
       // handle the message
-      if (null != message.payloadUtf8) {
-        Map<String, dynamic> payloadMap = jsonDecode(message.payloadUtf8);
-        log.fine(payloadMap['type']);
-        if ('CLOSE' == payloadMap['type']) {
-          _dispose();
-          connectionDidClose = true;
-        }
-        if ('RECEIVER_STATUS' == payloadMap['type']) {
-          _handleReceiverStatus(payloadMap);
-        } else if ('MEDIA_STATUS' == payloadMap['type']) {
-          _handleMediaStatus(payloadMap);
-        }
+      Map<String, dynamic> payloadMap = jsonDecode(message.payloadUtf8);
+      log.fine(payloadMap['type']);
+      if ('CLOSE' == payloadMap['type']) {
+        _dispose();
+        connectionDidClose = true;
+      }
+      if ('RECEIVER_STATUS' == payloadMap['type']) {
+        _handleReceiverStatus(payloadMap);
+      } else if ('MEDIA_STATUS' == payloadMap['type']) {
+        _handleMediaStatus(payloadMap);
       }
     }
   }
@@ -257,7 +254,7 @@ class CastSender extends Object {
         true == payload['status']?.containsKey('applications')) {
       // re-create the channel with the transportId the chromecast just sent us
       if (false == _castSession?.isConnected) {
-        _castSession = _castSession
+        _castSession = _castSession!
           ..mergeWithChromeCastSessionMap(payload['status']['applications'][0]);
         _connectionChannel = ConnectionChannel.create(_socket,
             sourceId: _castSession!.sourceId,

--- a/lib/casting/cast_session.dart
+++ b/lib/casting/cast_session.dart
@@ -2,9 +2,9 @@ import 'package:dart_chromecast/casting/cast_media_status.dart';
 
 class CastSession {
 
-  String sourceId;
-  String destinationId;
-  CastMediaStatus castMediaStatus;
+  String? sourceId;
+  String? destinationId;
+  CastMediaStatus? castMediaStatus;
 
   bool isConnected;
   bool isReadyForMedia = false;
@@ -20,7 +20,7 @@ class CastSession {
 
   // TODO: from apple tv map
 
-  Map<String, String> toMap() {
+  Map<String, String?> toMap() {
     return {
       'sourceId': sourceId,
       'destinationId': destinationId,

--- a/lib/casting/connection_channel.dart
+++ b/lib/casting/connection_channel.dart
@@ -4,7 +4,7 @@ import 'package:dart_chromecast/casting/cast_channel.dart';
 
 class ConnectionChannel extends CastChannel {
 
-  ConnectionChannel.create(Socket socket, {String sourceId, String destinationId}) :
+  ConnectionChannel.create(Socket? socket, {String? sourceId, String? destinationId}) :
         super.CreateWithSocket(socket, sourceId: sourceId ?? 'sender-0', destinationId: destinationId ?? 'receiver-0', namespace: 'urn:x-cast:com.google.cast.tp.connection');
 
 }

--- a/lib/casting/heartbeat_channel.dart
+++ b/lib/casting/heartbeat_channel.dart
@@ -1,11 +1,12 @@
 import 'dart:io';
 
 import 'package:dart_chromecast/casting/cast_channel.dart';
-import 'package:dart_chromecast/proto/cast_channel.pb.dart';
 
 class HeartbeatChannel extends CastChannel {
-
-  HeartbeatChannel.create(Socket? socket, {String? sourceId, String? destinationId}) :
-        super.CreateWithSocket(socket, sourceId: sourceId ?? 'sender-0', destinationId: destinationId ?? 'receiver-0', namespace: 'urn:x-cast:com.google.cast.tp.heartbeat');
-
+  HeartbeatChannel.create(Socket? socket,
+      {String? sourceId, String? destinationId})
+      : super.CreateWithSocket(socket,
+            sourceId: sourceId ?? 'sender-0',
+            destinationId: destinationId ?? 'receiver-0',
+            namespace: 'urn:x-cast:com.google.cast.tp.heartbeat');
 }

--- a/lib/casting/heartbeat_channel.dart
+++ b/lib/casting/heartbeat_channel.dart
@@ -5,7 +5,7 @@ import 'package:dart_chromecast/proto/cast_channel.pb.dart';
 
 class HeartbeatChannel extends CastChannel {
 
-  HeartbeatChannel.create(Socket socket, {String sourceId, String destinationId}) :
+  HeartbeatChannel.create(Socket? socket, {String? sourceId, String? destinationId}) :
         super.CreateWithSocket(socket, sourceId: sourceId ?? 'sender-0', destinationId: destinationId ?? 'receiver-0', namespace: 'urn:x-cast:com.google.cast.tp.heartbeat');
 
 }

--- a/lib/casting/interfaces/log_interface.dart
+++ b/lib/casting/interfaces/log_interface.dart
@@ -1,6 +1,6 @@
 class LogInterface {
 
-  Function _logCallback;
+  Function? _logCallback;
 
   setLogCallback(void logCallback(Error e, String s)) {
     _logCallback = logCallback;
@@ -8,13 +8,13 @@ class LogInterface {
 
   logInfo(String message) {
     if (null != _logCallback) {
-      _logCallback(null, message);
+      _logCallback!(null, message);
     }
   }
 
-  logError(String message, [ Object error ]) {
+  logError(String message, [ Object? error ]) {
     if (null != _logCallback) {
-      _logCallback(error, message);
+      _logCallback!(error, message);
     }
   }
 

--- a/lib/casting/media_channel.dart
+++ b/lib/casting/media_channel.dart
@@ -4,7 +4,7 @@ import 'package:dart_chromecast/casting/cast_channel.dart';
 
 class MediaChannel extends CastChannel {
 
-  MediaChannel.Create({Socket socket, String sourceId, String destinationId}) :
+  MediaChannel.Create({Socket? socket, String? sourceId, String? destinationId}) :
       super.CreateWithSocket(socket, sourceId: sourceId, destinationId: destinationId, namespace: 'urn:x-cast:com.google.cast.media');
 
 }

--- a/lib/casting/receiver_channel.dart
+++ b/lib/casting/receiver_channel.dart
@@ -5,7 +5,7 @@ import 'package:dart_chromecast/proto/cast_channel.pb.dart';
 
 class ReceiverChannel extends CastChannel {
 
-  ReceiverChannel.create(Socket socket, {String sourceId, String destinationId}) :
+  ReceiverChannel.create(Socket? socket, {String? sourceId, String? destinationId}) :
         super.CreateWithSocket(socket, sourceId: sourceId ?? 'sender-0', destinationId: destinationId ?? 'receiver-0', namespace: 'urn:x-cast:com.google.cast.receiver');
 
 }

--- a/lib/casting/receiver_channel.dart
+++ b/lib/casting/receiver_channel.dart
@@ -1,11 +1,12 @@
 import 'dart:io';
 
 import 'package:dart_chromecast/casting/cast_channel.dart';
-import 'package:dart_chromecast/proto/cast_channel.pb.dart';
 
 class ReceiverChannel extends CastChannel {
-
-  ReceiverChannel.create(Socket? socket, {String? sourceId, String? destinationId}) :
-        super.CreateWithSocket(socket, sourceId: sourceId ?? 'sender-0', destinationId: destinationId ?? 'receiver-0', namespace: 'urn:x-cast:com.google.cast.receiver');
-
+  ReceiverChannel.create(Socket? socket,
+      {String? sourceId, String? destinationId})
+      : super.CreateWithSocket(socket,
+            sourceId: sourceId ?? 'sender-0',
+            destinationId: destinationId ?? 'receiver-0',
+            namespace: 'urn:x-cast:com.google.cast.receiver');
 }

--- a/lib/proto/cast_channel.pb.dart
+++ b/lib/proto/cast_channel.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: lib/proto/cast_channel.proto
 //
-// @dart = 2.3
+
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 import 'dart:core' as $core;
@@ -29,7 +29,7 @@ class CastMessage extends $pb.GeneratedMessage {
   factory CastMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory CastMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   CastMessage clone() => CastMessage()..mergeFromMessage(this);
-  CastMessage copyWith(void Function(CastMessage) updates) => super.copyWith((message) => updates(message as CastMessage));
+  CastMessage copyWith(void Function(CastMessage) updates) => super.copyWith((message) => updates(message as CastMessage)) as CastMessage;
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CastMessage create() => CastMessage._();
@@ -37,7 +37,7 @@ class CastMessage extends $pb.GeneratedMessage {
   static $pb.PbList<CastMessage> createRepeated() => $pb.PbList<CastMessage>();
   @$core.pragma('dart2js:noInline')
   static CastMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CastMessage>(create);
-  static CastMessage _defaultInstance;
+  static CastMessage? _defaultInstance;
 
   @$pb.TagNumber(1)
   CastMessage_ProtocolVersion get protocolVersion => $_getN(0);
@@ -113,7 +113,7 @@ class AuthChallenge extends $pb.GeneratedMessage {
   factory AuthChallenge.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory AuthChallenge.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   AuthChallenge clone() => AuthChallenge()..mergeFromMessage(this);
-  AuthChallenge copyWith(void Function(AuthChallenge) updates) => super.copyWith((message) => updates(message as AuthChallenge));
+  AuthChallenge copyWith(void Function(AuthChallenge) updates) => super.copyWith((message) => updates(message as AuthChallenge)) as AuthChallenge;
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AuthChallenge create() => AuthChallenge._();
@@ -121,7 +121,7 @@ class AuthChallenge extends $pb.GeneratedMessage {
   static $pb.PbList<AuthChallenge> createRepeated() => $pb.PbList<AuthChallenge>();
   @$core.pragma('dart2js:noInline')
   static AuthChallenge getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AuthChallenge>(create);
-  static AuthChallenge _defaultInstance;
+  static AuthChallenge? _defaultInstance;
 }
 
 class AuthResponse extends $pb.GeneratedMessage {
@@ -136,7 +136,7 @@ class AuthResponse extends $pb.GeneratedMessage {
   factory AuthResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory AuthResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   AuthResponse clone() => AuthResponse()..mergeFromMessage(this);
-  AuthResponse copyWith(void Function(AuthResponse) updates) => super.copyWith((message) => updates(message as AuthResponse));
+  AuthResponse copyWith(void Function(AuthResponse) updates) => super.copyWith((message) => updates(message as AuthResponse)) as AuthResponse;
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AuthResponse create() => AuthResponse._();
@@ -144,7 +144,7 @@ class AuthResponse extends $pb.GeneratedMessage {
   static $pb.PbList<AuthResponse> createRepeated() => $pb.PbList<AuthResponse>();
   @$core.pragma('dart2js:noInline')
   static AuthResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AuthResponse>(create);
-  static AuthResponse _defaultInstance;
+  static AuthResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get signature => $_getN(0);
@@ -178,7 +178,7 @@ class AuthError extends $pb.GeneratedMessage {
   factory AuthError.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory AuthError.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   AuthError clone() => AuthError()..mergeFromMessage(this);
-  AuthError copyWith(void Function(AuthError) updates) => super.copyWith((message) => updates(message as AuthError));
+  AuthError copyWith(void Function(AuthError) updates) => super.copyWith((message) => updates(message as AuthError)) as AuthError;
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AuthError create() => AuthError._();
@@ -186,7 +186,7 @@ class AuthError extends $pb.GeneratedMessage {
   static $pb.PbList<AuthError> createRepeated() => $pb.PbList<AuthError>();
   @$core.pragma('dart2js:noInline')
   static AuthError getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AuthError>(create);
-  static AuthError _defaultInstance;
+  static AuthError? _defaultInstance;
 
   @$pb.TagNumber(1)
   AuthError_ErrorType get errorType => $_getN(0);
@@ -210,7 +210,7 @@ class DeviceAuthMessage extends $pb.GeneratedMessage {
   factory DeviceAuthMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory DeviceAuthMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   DeviceAuthMessage clone() => DeviceAuthMessage()..mergeFromMessage(this);
-  DeviceAuthMessage copyWith(void Function(DeviceAuthMessage) updates) => super.copyWith((message) => updates(message as DeviceAuthMessage));
+  DeviceAuthMessage copyWith(void Function(DeviceAuthMessage) updates) => super.copyWith((message) => updates(message as DeviceAuthMessage)) as DeviceAuthMessage;
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DeviceAuthMessage create() => DeviceAuthMessage._();
@@ -218,7 +218,7 @@ class DeviceAuthMessage extends $pb.GeneratedMessage {
   static $pb.PbList<DeviceAuthMessage> createRepeated() => $pb.PbList<DeviceAuthMessage>();
   @$core.pragma('dart2js:noInline')
   static DeviceAuthMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeviceAuthMessage>(create);
-  static DeviceAuthMessage _defaultInstance;
+  static DeviceAuthMessage? _defaultInstance;
 
   @$pb.TagNumber(1)
   AuthChallenge get challenge => $_getN(0);

--- a/lib/proto/cast_channel.pbenum.dart
+++ b/lib/proto/cast_channel.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: lib/proto/cast_channel.proto
 //
-// @dart = 2.3
+
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
@@ -17,7 +17,7 @@ class CastMessage_ProtocolVersion extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, CastMessage_ProtocolVersion> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static CastMessage_ProtocolVersion valueOf($core.int value) => _byValue[value];
+  static CastMessage_ProtocolVersion? valueOf($core.int value) => _byValue[value];
 
   const CastMessage_ProtocolVersion._($core.int v, $core.String n) : super(v, n);
 }
@@ -32,7 +32,7 @@ class CastMessage_PayloadType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, CastMessage_PayloadType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static CastMessage_PayloadType valueOf($core.int value) => _byValue[value];
+  static CastMessage_PayloadType? valueOf($core.int value) => _byValue[value];
 
   const CastMessage_PayloadType._($core.int v, $core.String n) : super(v, n);
 }
@@ -47,7 +47,7 @@ class AuthError_ErrorType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, AuthError_ErrorType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static AuthError_ErrorType valueOf($core.int value) => _byValue[value];
+  static AuthError_ErrorType? valueOf($core.int value) => _byValue[value];
 
   const AuthError_ErrorType._($core.int v, $core.String n) : super(v, n);
 }

--- a/lib/proto/cast_channel.pbenum.dart
+++ b/lib/proto/cast_channel.pbenum.dart
@@ -5,50 +5,60 @@
 
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
+// ignore_for_file: UNDEFINED_SHOWN_NAME
 import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class CastMessage_ProtocolVersion extends $pb.ProtobufEnum {
-  static const CastMessage_ProtocolVersion CASTV2_1_0 = CastMessage_ProtocolVersion._(0, 'CASTV2_1_0');
+  static const CastMessage_ProtocolVersion CASTV2_1_0 =
+      CastMessage_ProtocolVersion._(0, 'CASTV2_1_0');
 
-  static const $core.List<CastMessage_ProtocolVersion> values = <CastMessage_ProtocolVersion> [
+  static const $core.List<CastMessage_ProtocolVersion> values =
+      <CastMessage_ProtocolVersion>[
     CASTV2_1_0,
   ];
 
-  static final $core.Map<$core.int, CastMessage_ProtocolVersion> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static CastMessage_ProtocolVersion? valueOf($core.int value) => _byValue[value];
+  static final $core.Map<$core.int, CastMessage_ProtocolVersion> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
+  static CastMessage_ProtocolVersion? valueOf($core.int value) =>
+      _byValue[value];
 
-  const CastMessage_ProtocolVersion._($core.int v, $core.String n) : super(v, n);
+  const CastMessage_ProtocolVersion._($core.int v, $core.String n)
+      : super(v, n);
 }
 
 class CastMessage_PayloadType extends $pb.ProtobufEnum {
-  static const CastMessage_PayloadType STRING = CastMessage_PayloadType._(0, 'STRING');
-  static const CastMessage_PayloadType BINARY = CastMessage_PayloadType._(1, 'BINARY');
+  static const CastMessage_PayloadType STRING =
+      CastMessage_PayloadType._(0, 'STRING');
+  static const CastMessage_PayloadType BINARY =
+      CastMessage_PayloadType._(1, 'BINARY');
 
-  static const $core.List<CastMessage_PayloadType> values = <CastMessage_PayloadType> [
+  static const $core.List<CastMessage_PayloadType> values =
+      <CastMessage_PayloadType>[
     STRING,
     BINARY,
   ];
 
-  static final $core.Map<$core.int, CastMessage_PayloadType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, CastMessage_PayloadType> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static CastMessage_PayloadType? valueOf($core.int value) => _byValue[value];
 
   const CastMessage_PayloadType._($core.int v, $core.String n) : super(v, n);
 }
 
 class AuthError_ErrorType extends $pb.ProtobufEnum {
-  static const AuthError_ErrorType INTERNAL_ERROR = AuthError_ErrorType._(0, 'INTERNAL_ERROR');
+  static const AuthError_ErrorType INTERNAL_ERROR =
+      AuthError_ErrorType._(0, 'INTERNAL_ERROR');
   static const AuthError_ErrorType NO_TLS = AuthError_ErrorType._(1, 'NO_TLS');
 
-  static const $core.List<AuthError_ErrorType> values = <AuthError_ErrorType> [
+  static const $core.List<AuthError_ErrorType> values = <AuthError_ErrorType>[
     INTERNAL_ERROR,
     NO_TLS,
   ];
 
-  static final $core.Map<$core.int, AuthError_ErrorType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, AuthError_ErrorType> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static AuthError_ErrorType? valueOf($core.int value) => _byValue[value];
 
   const AuthError_ErrorType._($core.int v, $core.String n) : super(v, n);
 }
-

--- a/lib/proto/cast_channel.pbjson.dart
+++ b/lib/proto/cast_channel.pbjson.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: lib/proto/cast_channel.proto
 //
-// @dart = 2.3
+
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 const CastMessage$json = const {

--- a/lib/proto/cast_channel.pbserver.dart
+++ b/lib/proto/cast_channel.pbserver.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: lib/proto/cast_channel.proto
 //
-// @dart = 2.3
+
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 export 'cast_channel.pb.dart';

--- a/lib/utils/mdns_find_chromecast.dart
+++ b/lib/utils/mdns_find_chromecast.dart
@@ -1,9 +1,9 @@
 import 'package:multicast_dns/multicast_dns.dart';
 
 class CastDevice {
-  final String name;
-  final String ip;
-  final int port;
+  final String? name;
+  final String? ip;
+  final int? port;
 
   CastDevice({this.name, this.ip, this.port});
 

--- a/lib/utils/mdns_find_chromecast.dart
+++ b/lib/utils/mdns_find_chromecast.dart
@@ -7,7 +7,7 @@ class CastDevice {
 
   CastDevice({this.name, this.ip, this.port});
 
-  String toString() => "CastDevice: ${name} -> ${ip}:${port}";
+  String toString() => "CastDevice: $name -> $ip:$port";
 }
 
 Future<List<CastDevice>> find_chromecasts() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,15 +4,17 @@ description: Cast videos to your ChromeCast device using Dart
 homepage: https://github.com/terrabythia/dart_chromecast
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  protobuf: '>=1.0.1 <2.0.0'
-  protoc_plugin: ^19.0.0
-  http: ^0.12.2
-  cli_util: ^0.2.0
-  args: ^1.6.0
-  xml: ^4.1.1
-  observable: ^0.22.2
-  logging: ^0.11.4
-  multicast_dns: ^0.2.2
+  flutter:
+    sdk: flutter
+    
+  protobuf: ^2.0.0
+  protoc_plugin: ^20.0.0
+  http: ^0.13.1
+  cli_util: ^0.3.0
+  args: ^2.0.0
+  xml: ^5.0.2
+  logging: ^1.0.1
+  multicast_dns: ^0.3.0


### PR DESCRIPTION
I started migrating this package to null safety.  This one is critical for our app, so we took the initiative to migrate it ourselves.  Most of the changes are simply the automatic suggestions you get from `dart migrate`

One challenge is that one of your dependancies - observable, hasn't been migrated yet.  Since that is a rather large google package, it seems easier to replace observable with flutter, which provides a null safe version of `ChangeNotifier`

While I know this package is `dart_chromecast` and not `flutter_chromecast` this compromise seems acceptable in the meanwhile since null safety is more important in the short term than keeping this package separate from Flutter.  After observable migrates (there is a WIP branch that has already been started), the Flutter dependancy can be removed.