### PR TITLE
Deps: allow for xml 6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Pure dart package to cast videos to your ChromeCast device and cont
 homepage: https://github.com/terrabythia/dart_chromecast
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   universal_io: ^2.0.4
@@ -12,6 +12,6 @@ dependencies:
   http: ^0.13.4
   cli_util: ^0.3.5
   args: ^2.3.0
-  xml: ^5.3.1
+  xml: ">=5.3.1 <7.0.0"
   logging: ^1.0.2
   multicast_dns: ^0.3.1


### PR DESCRIPTION
Current version of the package is preventing us to upgrade to XML 6 and some related dependencies. Would you accept this / require any extra change or check? 