### PR TITLE
Migrate to cast_device.dart universal_io

### DIFF
--- a/lib/casting/cast_device.dart
+++ b/lib/casting/cast_device.dart
@@ -2,8 +2,6 @@ import 'dart:convert';
 import 'dart:convert' show utf8;
 import 'dart:typed_data';
 
-import 'package:http/http.dart' as http;
-import 'package:http/io_client.dart';
 import 'package:logging/logging.dart';
 import 'package:universal_io/io.dart';
 
@@ -75,11 +73,11 @@ class CastDevice {
             ..badCertificateCallback =
                 ((X509Certificate cert, String host, int port) =>
                     trustSelfSigned);
-          IOClient ioClient = new IOClient(httpClient);
           final uri = Uri.parse(
               'https://$host:8443/setup/eureka_info?params=name,device_info');
-          http.Response response = await ioClient.get(uri);
-          Map deviceInfo = jsonDecode(response.body);
+          final request = await httpClient.getUrl(uri);
+          final response = await request.close();
+          Map deviceInfo = jsonDecode(response.toString());
 
           if (deviceInfo['name'] != null && deviceInfo['name'] != 'Unknown') {
             _friendlyName = deviceInfo['name'];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ description: Pure dart package to cast videos to your ChromeCast device and cont
 homepage: https://github.com/terrabythia/dart_chromecast
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ^3.4.4
 
 dependencies:
   universal_io: ^2.0.4
   protobuf: ^2.0.1
-  http: ^0.13.4
+  http: ^1.0.0
   cli_util: ^0.3.5
   args: ^2.3.0
   xml: ">=5.3.1 <7.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   universal_io: ^2.0.4
   protobuf: ^2.0.1
-  http: ^1.0.0
+  http: ^0.13.5
   cli_util: ^0.3.5
   args: ^2.3.0
   xml: ">=5.3.1 <7.0.0"


### PR DESCRIPTION
This contributes to cross-platform compatibility by allowing the developer to compile for at least (tested) Android, Web and Linux without changes to the code.