### PR TITLE
update http package to latest 1.1.0 to avoid old dependency conflicts…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   universal_io: ^2.0.4
   protobuf: ^2.0.1
-  http: ^0.13.4
+  http: ^1.1.0
   cli_util: ^0.3.5
   args: ^2.3.0
   xml: ">=5.3.1 <7.0.0"


### PR DESCRIPTION
… in recent projects using http,

Recently i was trying to use dart_chromecast in my flutter project that has http 1.1.0 ( latest at the moment ) and pubspec inspector trowed a dependency incompatibility issue, it would be nice to update this in the pub.dev also.

Thanks for the amazing cast package ! lifesaver 